### PR TITLE
Integrate dg-models-orchestrator for detection and classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ Detections are split by confidence:
 Hand-drawn boxes work exactly as before: click-and-drag to draw, click to
 select, <kbd>Delete</kbd> to remove, double-click to rename.
 
+Unsaved changes are **auto-saved when you navigate** to another image
+(sidebar click, Prev/Next, arrow keys) — you can always come back and fix an
+image later.
+
+### Image orientation
+
+EXIF orientation is respected end to end: the app reports the *displayed*
+dimensions, and images carrying a non-default orientation tag are transposed
+before being sent for inference, so detection boxes line up with what the
+browser shows.
+
+### Crop & rotate
+
+The toolbar's **⟲ 90° / ⟳ 90°** buttons rotate the image; **✂ Crop** lets
+you drag a region and apply it (<kbd>Esc</kbd> cancels). Edits are saved as a
+copy in the same folder (`<base>_edited.jpg`; editing an already-edited image
+overwrites it in place), with EXIF orientation baked in. Saved boxes and
+candidates are remapped onto the edited image (boxes falling outside a crop
+are dropped). The original file stays on disk, but is excluded from the image
+lists unless it has saved boxes of its own.
+
 ### Exports
 
 In the right-hand panel:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 # Image Labelling / Sorting App
 
-A lightweight FastAPI app that helps you build image datasets two ways:
+A lightweight FastAPI app that helps you build image datasets three ways:
 
 1. **Classification** – move images into labelled folders (the original flow).
-2. **Object Detection** – draw bounding boxes on images, optionally pre-filled
-   by an external model, then export to COCO / Pascal VOC / YOLO or to a Vertex
-   AI object-detection CSV.
+2. **Model-assisted classification** – the `cutter_wear` and `wear_type`
+   models suggest a label per image; the label you click decides which folder
+   the image is sorted into.
+3. **Object Detection** – draw bounding boxes on images, optionally pre-filled
+   by the `cutter_detect` or `blade_crop` models, then export to COCO /
+   Pascal VOC / YOLO or to a Vertex AI object-detection CSV.
+
+All model inference goes through the
+[dg-models-orchestrator](https://github.com/darkcirrusai/dg-models-orchestrator)
+— this app never talks to the TFServing containers directly. Configure it with
+the `ORCHESTRATOR_URL` and `ORCHESTRATOR_API_KEY` environment variables (or
+`orchestrator_url` / `orchestrator_api_key` in `detect_config.json`). The
+orchestrator returns raw TFServing predictions; parsing lives in
+`orchestrator_client.py`.
 
 ## Environment
 Python 3.8+, FastAPI 0.86.0
@@ -31,6 +42,21 @@ Place images into `source_files/`. Annotations are stored as JSON under
 Open <http://127.0.0.1:8000/>, enter a category in the right-hand form, and the
 image is moved into `sorted_files/<category>/`.
 
+## Model-assisted classification
+
+Open <http://127.0.0.1:8000/classify> and pick a module:
+
+| Module | Orchestrator endpoint | What it classifies |
+|--------|----------------------|--------------------|
+| `cutter_wear` | `/cutter-wear` | Wear level of a cutter |
+| `wear_type` | `/cutter-class` | Wear/cutter type |
+
+Each image is sent to the orchestrator (automatically, or via **✨ Predict**)
+and the per-class scores are shown as clickable buttons. Clicking a label —
+the suggested one, another class, or a custom label — moves the image into
+`sorted_files/<module>/<label>/` and advances to the next image. The model
+only suggests; nothing is saved until you click.
+
 ## Object Detection
 
 Open <http://127.0.0.1:8000/detect>.
@@ -44,28 +70,29 @@ Open <http://127.0.0.1:8000/detect>.
 
 ### Auto-annotation
 
-The `✨ Auto-annotate` button asks a model for boxes, which are merged with any
-you have already drawn so you can edit them before saving.
+The `✨ Auto-annotate` button asks the orchestrator for boxes. Pick the model
+in the toolbar:
 
-Two backends are supported:
+* **Cutter detection** (`/cutter-detect`) — combines both detection models,
+  labels boxes `cutter` / `lost` / `nozzle` / `ring_out`, and drops duplicate
+  detections (same label, IOU > 0.5, higher score wins). If one of the two
+  models fails, the other's detections are still used and a warning is shown.
+* **Blade crop** (`/blade-crop`) — returns `blade` boxes.
 
-1. **Remote model endpoint.** Enter the URL in the right-hand panel (or put it
-   in `detect_config.json` as `{ "auto_endpoint": "https://…/predict" }`). The
-   server will POST the image as a `multipart/form-data` `file` field and
-   expects JSON like:
+Detections are split by confidence:
 
-   ```json
-   {"boxes": [
-     {"label": "cat", "x": 10, "y": 12, "width": 80, "height": 120, "score": 0.91}
-   ]}
-   ```
+* **Boxes** (score ≥ *Threshold*, default 50%) are added to the annotation
+  set. **Click a model detection to reject it** — it turns grey with a cross
+  and is dropped on save; click it again (or use ↩ in the box list) to
+  restore it.
+* **Candidates** (*Cand. ≥* ≤ score < *Threshold*, default 20–50%) are drawn
+  as dashed amber boxes. **Click a candidate to accept it** into the
+  annotation set; unaccepted candidates are simply ignored — they are stored
+  alongside the annotation so they survive navigation, but never appear in
+  any export.
 
-   `xmin/ymin/xmax/ymax` coordinates are also accepted.
-
-2. **Local torchvision Faster R-CNN.** If no endpoint is configured and
-   `torchvision` is installed, the bundled COCO-pretrained Faster R-CNN is
-   used. Install with `pip install torch torchvision` (kept optional because
-   it’s large).
+Hand-drawn boxes work exactly as before: click-and-drag to draw, click to
+select, <kbd>Delete</kbd> to remove, double-click to rename.
 
 ### Exports
 
@@ -98,9 +125,10 @@ at its `gs://` URI.
 ```
 source_files/       # drop images here
 sorted_files/       # classifier moves images here by label
-annotations/        # per-image JSON: {image, boxes: [{label,x,y,width,height,score?}]}
+                    #   (model-assisted flow uses sorted_files/<module>/<label>/)
+annotations/        # per-image JSON: {image, boxes: [...], candidates: [...]}
 exports/            # generated export files (Vertex CSVs, etc.)
-detect_config.json  # optional: {"auto_endpoint": "..."} for auto-annotation
+detect_config.json  # optional: {"orchestrator_url": "...", "orchestrator_api_key": "..."}
 ```
 
 ## Future Developments

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 
 # 1. Library imports
-import base64
 import csv
 import io
 import json
@@ -22,11 +21,12 @@ from fastapi.templating import Jinja2Templates
 from PIL import Image
 from pydantic import BaseModel
 
+import orchestrator_client
+
 UPLOAD_FOLDER = 'sorted_files'
 image_folder = 'source_files'
 ANNOTATIONS_DIR = 'annotations'
 EXPORTS_DIR = 'exports'
-CONFIG_PATH = 'detect_config.json'
 
 IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.bmp', '.gif', '.webp'}
 
@@ -118,14 +118,16 @@ class Box(BaseModel):
 class AnnotationPayload(BaseModel):
     image: str
     boxes: List[Box]
+    candidates: List[Box] = []
     image_width: Optional[int] = None
     image_height: Optional[int] = None
 
 
 class AutoAnnotateRequest(BaseModel):
     image: str
-    endpoint: Optional[str] = None
+    module: str = "cutter_detect"
     threshold: float = 0.5
+    candidate_threshold: float = 0.2
 
 
 class GCPExportRequest(BaseModel):
@@ -222,6 +224,9 @@ def api_save_annotation(payload: AnnotationPayload):
     data = {
         "image": payload.image,
         "boxes": [b.model_dump() for b in payload.boxes],
+        # Unaccepted model candidates (20-50% confidence by default) are kept
+        # so they survive navigation, but are excluded from every export.
+        "candidates": [b.model_dump() for b in payload.candidates],
         "image_width": payload.image_width,
         "image_height": payload.image_height,
         "updated_at": datetime.now(timezone.utc).isoformat() + "Z",
@@ -259,169 +264,138 @@ def api_list_labels():
 
 
 # ---------------------------------------------------------------------------
-# Auto-annotation via an external model endpoint
+# Auto-annotation via the model orchestrator
 # ---------------------------------------------------------------------------
 @app.post("/api/detect/auto")
 def api_auto_annotate(payload: AutoAnnotateRequest):
     """
-    Request boxes from a model. Two options are supported:
+    Request detections from the dg-models-orchestrator.
 
-    1. A user-provided HTTP endpoint that accepts a multipart image upload and
-       returns JSON like {"boxes": [{"label": ..., "x":..,"y":..,"width":..,
-       "height":..,"score":..}, ...]} where coordinates are absolute pixels.
-    2. A locally-installed torchvision Faster R-CNN model (used when no
-       endpoint is provided and torchvision is importable).
+    ``module`` selects the detection model: ``cutter_detect`` (dual-model
+    cutter/lost/nozzle/ring_out detection) or ``blade_crop``.
+
+    Detections scoring at or above ``threshold`` are returned as ``boxes``.
+    Detections in ``[candidate_threshold, threshold)`` are returned as
+    ``candidates`` — shown to the user, who accepts them into the annotation
+    set by clicking or leaves them to be ignored.
     """
     image_path = os.path.join(image_folder, payload.image)
     if not os.path.exists(image_path):
         raise HTTPException(status_code=404, detail="image not found")
+    if payload.module not in orchestrator_client.DETECT_MODULES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown module '{payload.module}'. "
+                   f"Available: {sorted(orchestrator_client.DETECT_MODULES)}")
+    if payload.candidate_threshold > payload.threshold:
+        raise HTTPException(status_code=400,
+                            detail="candidate_threshold must not exceed threshold")
 
-    endpoint = payload.endpoint or _load_config().get("auto_endpoint") or os.getenv("MODEL_URL")
-
-    if endpoint:
-        try:
-            if "/v1/models/" in endpoint:
-                boxes = _tfserving_detect(image_path, endpoint, payload.threshold)
-            else:
-                boxes = _remote_detect(image_path, endpoint, payload.threshold)
-        except Exception as exc:  # noqa: BLE001
-            raise HTTPException(status_code=502,
-                                detail=f"remote model failed: {exc}")
-    else:
-        try:
-            boxes = _local_detect(image_path, payload.threshold)
-        except ModuleNotFoundError:
-            raise HTTPException(
-                status_code=503,
-                detail=("No auto-detection model available. Install torchvision "
-                        "or provide a model endpoint in detect_config.json."),
-            )
-        except Exception as exc:  # noqa: BLE001
-            raise HTTPException(status_code=500,
-                                detail=f"local model failed: {exc}")
-
-    return {"boxes": boxes}
-
-
-_CUTTER_CLASS_LABELS = {1: "nozzles", 3: "cutter", 4: "ro"}
-
-
-def _tfserving_detect(image_path: str, endpoint: str, threshold: float) -> List[Dict[str, Any]]:
-    """Send a prediction request in TFServing base64-JSON format and parse the response."""
-    import requests
-    with open(image_path, "rb") as fh:
-        encoded = base64.b64encode(fh.read()).decode("utf-8")
-    key = os.path.basename(image_path)
-    payload = {
-        "instances": [{"image_bytes": {"b64": encoded}, "key": key}]
-    }
-    resp = requests.post(endpoint, data=json.dumps(payload), timeout=60)
-    resp.raise_for_status()
-    data = resp.json()
     try:
-        pred = data["predictions"][0]
-    except (KeyError, IndexError):
-        return []
-    with Image.open(image_path) as img:
-        img_w, img_h = img.size
-    boxes = []
-    det_boxes = pred.get("detection_boxes", [])
-    det_scores = pred.get("detection_scores", [])
-    det_classes_text = pred.get("detection_classes_as_text", [])
-    det_classes = pred.get("detection_classes", [])
-    labels = det_classes_text if det_classes_text else [
-        _CUTTER_CLASS_LABELS.get(int(c), f"class_{int(c)}") for c in det_classes
+        img_w, img_h = _image_dimensions(payload.image)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=f"could not read image: {exc}")
+
+    try:
+        detections, warning = orchestrator_client.detect(
+            payload.module, image_path, payload.image, img_w, img_h)
+    except orchestrator_client.OrchestratorError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    boxes = [d for d in detections if d["score"] >= payload.threshold]
+    candidates = [
+        d for d in detections
+        if payload.candidate_threshold <= d["score"] < payload.threshold
     ]
-    for box, score, label in zip(det_boxes, det_scores, labels):
-        score = float(score)
-        if score < threshold:
-            continue
-        ymin, xmin, ymax, xmax = box
-        x = float(xmin) * img_w
-        y = float(ymin) * img_h
-        w = (float(xmax) - float(xmin)) * img_w
-        h = (float(ymax) - float(ymin)) * img_h
-        boxes.append({"label": label, "x": x, "y": y, "width": w, "height": h, "score": score})
-    return boxes
+    return {"boxes": boxes, "candidates": candidates, "warning": warning}
 
 
-def _remote_detect(image_path: str, endpoint: str, threshold: float) -> List[Dict[str, Any]]:
-    import requests  # imported lazily to keep requests optional
-
-    with open(image_path, "rb") as fh:
-        files = {"file": (os.path.basename(image_path), fh, "application/octet-stream")}
-        resp = requests.post(endpoint, files=files, timeout=60)
-    resp.raise_for_status()
-    data = resp.json()
-    raw_boxes = data.get("boxes", data if isinstance(data, list) else [])
-    boxes = []
-    for b in raw_boxes:
-        score = b.get("score")
-        if score is not None and score < threshold:
-            continue
-        # Accept either x/y/width/height or xmin/ymin/xmax/ymax shapes.
-        if "xmin" in b:
-            x = float(b["xmin"])
-            y = float(b["ymin"])
-            w = float(b["xmax"]) - x
-            h = float(b["ymax"]) - y
-        else:
-            x = float(b["x"])
-            y = float(b["y"])
-            w = float(b["width"])
-            h = float(b["height"])
-        boxes.append({
-            "label": str(b.get("label", "object")),
-            "x": x, "y": y, "width": w, "height": h,
-            "score": float(score) if score is not None else None,
-        })
-    return boxes
+# ---------------------------------------------------------------------------
+# Classification modules (cutter_wear, wear_type) via the orchestrator
+# ---------------------------------------------------------------------------
+class ClassifyPredictRequest(BaseModel):
+    image: str
+    module: str
 
 
-_LOCAL_MODEL = None
-_LOCAL_LABELS = None
+class ClassifyAssignRequest(BaseModel):
+    image: str
+    module: str
+    label: str
 
 
-def _local_detect(image_path: str, threshold: float) -> List[Dict[str, Any]]:
-    global _LOCAL_MODEL, _LOCAL_LABELS
-    import torch  # type: ignore
-    import torchvision  # type: ignore
-    from torchvision.transforms import functional as TF  # type: ignore
-
-    if _LOCAL_MODEL is None:
-        weights = torchvision.models.detection.FasterRCNN_ResNet50_FPN_Weights.DEFAULT
-        _LOCAL_MODEL = torchvision.models.detection.fasterrcnn_resnet50_fpn(weights=weights)
-        _LOCAL_MODEL.eval()
-        _LOCAL_LABELS = weights.meta["categories"]
-
-    with Image.open(image_path).convert("RGB") as img:
-        tensor = TF.to_tensor(img)
-    with torch.no_grad():
-        outputs = _LOCAL_MODEL([tensor])[0]
-
-    boxes = []
-    for box, score, label_id in zip(outputs["boxes"], outputs["scores"], outputs["labels"]):
-        s = float(score)
-        if s < threshold:
-            continue
-        x1, y1, x2, y2 = [float(v) for v in box.tolist()]
-        boxes.append({
-            "label": _LOCAL_LABELS[int(label_id)],
-            "x": x1, "y": y1,
-            "width": x2 - x1, "height": y2 - y1,
-            "score": s,
-        })
-    return boxes
+def _validate_classify_module(module: str) -> None:
+    if module not in orchestrator_client.CLASSIFY_MODULES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown module '{module}'. "
+                   f"Available: {sorted(orchestrator_client.CLASSIFY_MODULES)}")
 
 
-def _load_config() -> Dict[str, Any]:
-    if not os.path.exists(CONFIG_PATH):
-        return {}
+def _module_sorted_dir(module: str) -> str:
+    return os.path.join(UPLOAD_FOLDER, module)
+
+
+@app.get("/classify", response_class=HTMLResponse)
+async def classify_page(request: Request):
+    return templates.TemplateResponse(
+        request,
+        "classify.html",
+        {"modules": sorted(orchestrator_client.CLASSIFY_MODULES)},
+    )
+
+
+@app.get("/api/classify/state")
+def api_classify_state(module: str):
+    """Remaining images plus per-label counts already sorted for a module."""
+    _validate_classify_module(module)
+    counts: Dict[str, int] = {}
+    module_dir = _module_sorted_dir(module)
+    if os.path.isdir(module_dir):
+        for label in sorted(os.listdir(module_dir)):
+            label_dir = os.path.join(module_dir, label)
+            if os.path.isdir(label_dir):
+                counts[label] = len(_list_images(label_dir))
+    images = _list_images(image_folder)
+    return {
+        "module": module,
+        "images": [{"name": name, "url": f"/source_files/{quote(name)}"}
+                   for name in images],
+        "remaining": len(images),
+        "counts": counts,
+    }
+
+
+@app.post("/api/classify/predict")
+def api_classify_predict(payload: ClassifyPredictRequest):
+    """Ask the orchestrator to classify one image with the selected module."""
+    _validate_classify_module(payload.module)
+    image_path = os.path.join(image_folder, payload.image)
+    if not os.path.exists(image_path):
+        raise HTTPException(status_code=404, detail="image not found")
     try:
-        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except Exception:
-        return {}
+        result = orchestrator_client.classify(payload.module, image_path, payload.image)
+    except orchestrator_client.OrchestratorError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    return {"module": payload.module, "image": payload.image, **result}
+
+
+@app.post("/api/classify/assign")
+def api_classify_assign(payload: ClassifyAssignRequest):
+    """Move an image into sorted_files/<module>/<label>/."""
+    _validate_classify_module(payload.module)
+    label = payload.label.strip()
+    if not label or label in {".", ".."} or any(c in label for c in "/\\\0"):
+        raise HTTPException(status_code=400, detail="invalid label")
+    image_name = os.path.basename(payload.image)
+    image_path = os.path.join(image_folder, image_name)
+    if not os.path.exists(image_path):
+        raise HTTPException(status_code=404, detail="image not found")
+
+    target_dir = os.path.join(_module_sorted_dir(payload.module), label)
+    os.makedirs(target_dir, exist_ok=True)
+    shutil.move(image_path, os.path.join(target_dir, image_name))
+    return {"ok": True, "image": image_name, "module": payload.module, "label": label}
 
 
 # ---------------------------------------------------------------------------

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import csv
 import io
 import json
 import os
+import re
 import shutil
 import time
 from dotenv import load_dotenv, find_dotenv
@@ -18,7 +19,7 @@ from fastapi import FastAPI, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from PIL import Image
+from PIL import Image, ImageOps
 from pydantic import BaseModel
 
 import orchestrator_client
@@ -47,7 +48,7 @@ templates = Jinja2Templates(directory="templates/")
 # ---------------------------------------------------------------------------
 @app.get("/", response_class=HTMLResponse)
 async def read_root(request: Request):
-    img_list = _list_images(image_folder)
+    img_list = _list_active_images(image_folder)
     pic_rem = len(img_list)
     try:
         next_img = img_list[0]
@@ -73,11 +74,11 @@ def move(item_id: str, request: Request):
     negative_cat = len(os.listdir(os.path.join(UPLOAD_FOLDER, '1'))) if os.path.isdir(
         os.path.join(UPLOAD_FOLDER, '1')) else 0
 
-    pic_rem = len(_list_images(image_folder))
+    pic_rem = len(_list_active_images(image_folder))
 
     shutil.move(image_path, upload_path)
 
-    img_list = _list_images(image_folder)
+    img_list = _list_active_images(image_folder)
     next_img = img_list[0] if img_list else 'no images found in the folder'
     return templates.TemplateResponse(request, "welcome.html",
                                       {"image": next_img, "pic_rem": pic_rem,
@@ -147,6 +148,44 @@ def _list_images(folder: str) -> List[str]:
     )
 
 
+# Edited copies of an image are named <base>_edited.<ext> (then _edited_1,
+# _edited_2, … if taken). Editing an already-edited file overwrites it.
+_EDITED_RE = re.compile(r"_edited(_\d+)?$")
+
+
+def _is_edited_name(name: str) -> bool:
+    return bool(_EDITED_RE.search(os.path.splitext(name)[0]))
+
+
+def _edited_target_name(folder: str, name: str) -> str:
+    base, ext = os.path.splitext(name)
+    if _EDITED_RE.search(base):
+        return name
+    candidate = f"{base}_edited{ext}"
+    counter = 1
+    while os.path.exists(os.path.join(folder, candidate)):
+        candidate = f"{base}_edited_{counter}{ext}"
+        counter += 1
+    return candidate
+
+
+def _list_active_images(folder: str) -> List[str]:
+    """Images to work on: hide an original that has an edited copy unless the
+    original itself carries saved boxes."""
+    images = _list_images(folder)
+    bases = {os.path.splitext(n)[0] for n in images}
+    active = []
+    for name in images:
+        base = os.path.splitext(name)[0]
+        if not _is_edited_name(name):
+            pattern = re.compile(re.escape(base) + r"_edited(_\d+)?$")
+            superseded = any(pattern.fullmatch(b) for b in bases)
+            if superseded and not _read_annotation(name).get("boxes"):
+                continue
+        active.append(name)
+    return active
+
+
 def _annotation_path(image_name: str) -> str:
     base = os.path.splitext(image_name)[0]
     return os.path.join(ANNOTATIONS_DIR, f"{base}.json")
@@ -161,14 +200,15 @@ def _read_annotation(image_name: str) -> Dict[str, Any]:
 
 
 def _image_dimensions(image_name: str) -> tuple[int, int]:
+    """Displayed (EXIF-oriented) dimensions, matching what the browser shows."""
     path = os.path.join(image_folder, image_name)
     with Image.open(path) as img:
-        return img.size  # (width, height)
+        return ImageOps.exif_transpose(img).size  # (width, height)
 
 
 @app.get("/detect", response_class=HTMLResponse)
 async def detect_page(request: Request):
-    images = _list_images(image_folder)
+    images = _list_active_images(image_folder)
     annotated = sum(
         1 for name in images if os.path.exists(_annotation_path(name))
     )
@@ -185,7 +225,7 @@ async def detect_page(request: Request):
 
 @app.get("/api/detect/images")
 def api_list_images():
-    images = _list_images(image_folder)
+    images = _list_active_images(image_folder)
     return {
         "images": [
             {
@@ -311,6 +351,122 @@ def api_auto_annotate(payload: AutoAnnotateRequest):
 
 
 # ---------------------------------------------------------------------------
+# Image editing (rotate / crop)
+# ---------------------------------------------------------------------------
+class CropRect(BaseModel):
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+class ImageEditRequest(BaseModel):
+    image: str
+    rotate: int = 0  # clockwise degrees: -90, 0, 90, 180, 270
+    crop: Optional[CropRect] = None
+
+
+def _rotate_box(b: Dict[str, Any], rotate: int, w: float, h: float) -> Dict[str, Any]:
+    """Map a box through a clockwise rotation of the (w, h) image."""
+    x, y, bw, bh = b["x"], b["y"], b["width"], b["height"]
+    if rotate == 90:
+        return {**b, "x": h - y - bh, "y": x, "width": bh, "height": bw}
+    if rotate == 180:
+        return {**b, "x": w - x - bw, "y": h - y - bh}
+    if rotate == 270:
+        return {**b, "x": y, "y": w - x - bw, "width": bh, "height": bw}
+    return b
+
+
+def _crop_box(b: Dict[str, Any], cx: float, cy: float,
+              cw: float, ch: float) -> Optional[Dict[str, Any]]:
+    """Shift a box into the crop's coordinate space, clipping to its bounds;
+    boxes left smaller than 2px are dropped."""
+    x1 = max(b["x"] - cx, 0.0)
+    y1 = max(b["y"] - cy, 0.0)
+    x2 = min(b["x"] + b["width"] - cx, cw)
+    y2 = min(b["y"] + b["height"] - cy, ch)
+    if x2 - x1 < 2 or y2 - y1 < 2:
+        return None
+    return {**b, "x": x1, "y": y1, "width": x2 - x1, "height": y2 - y1}
+
+
+@app.post("/api/detect/edit")
+def api_edit_image(payload: ImageEditRequest):
+    """
+    Rotate and/or crop an image, saving the result as an edited copy in the
+    same folder (<base>_edited.<ext>; an already-edited image is overwritten
+    in place). Saved boxes and candidates are mapped into the edited image's
+    coordinates. The original is kept, but disappears from the image lists
+    unless it carries saved boxes of its own.
+
+    Rotation is applied first, so crop coordinates are in the rotated image's
+    pixel space (which is what the UI shows when both are combined).
+    """
+    image_path = os.path.join(image_folder, payload.image)
+    if not os.path.exists(image_path):
+        raise HTTPException(status_code=404, detail="image not found")
+    rotate = payload.rotate % 360
+    if rotate not in (0, 90, 180, 270):
+        raise HTTPException(status_code=400, detail="rotate must be a multiple of 90")
+    if rotate == 0 and payload.crop is None:
+        raise HTTPException(status_code=400, detail="nothing to do: no rotation or crop given")
+
+    annotation = _read_annotation(payload.image)
+    boxes = list(annotation.get("boxes") or [])
+    candidates = list(annotation.get("candidates") or [])
+
+    with Image.open(image_path) as img:
+        im = ImageOps.exif_transpose(img)
+        w, h = im.size
+
+        if rotate:
+            transpose = {90: Image.Transpose.ROTATE_270,
+                         180: Image.Transpose.ROTATE_180,
+                         270: Image.Transpose.ROTATE_90}[rotate]
+            im = im.transpose(transpose)
+            boxes = [_rotate_box(b, rotate, w, h) for b in boxes]
+            candidates = [_rotate_box(b, rotate, w, h) for b in candidates]
+            w, h = im.size
+
+        if payload.crop is not None:
+            cx = max(0, int(round(payload.crop.x)))
+            cy = max(0, int(round(payload.crop.y)))
+            cx2 = min(w, int(round(payload.crop.x + payload.crop.width)))
+            cy2 = min(h, int(round(payload.crop.y + payload.crop.height)))
+            if cx2 - cx < 8 or cy2 - cy < 8:
+                raise HTTPException(status_code=400, detail="crop region is too small")
+            im = im.crop((cx, cy, cx2, cy2))
+            cw, ch = float(cx2 - cx), float(cy2 - cy)
+            boxes = [t for b in boxes if (t := _crop_box(b, cx, cy, cw, ch))]
+            candidates = [t for b in candidates if (t := _crop_box(b, cx, cy, cw, ch))]
+            w, h = im.size
+
+        target = _edited_target_name(image_folder, payload.image)
+        target_path = os.path.join(image_folder, target)
+        if os.path.splitext(target)[1].lower() in {".jpg", ".jpeg"} and im.mode != "RGB":
+            im = im.convert("RGB")
+        im.save(target_path)
+
+    target_ann = _annotation_path(target)
+    if boxes or candidates:
+        with open(target_ann, "w", encoding="utf-8") as fh:
+            json.dump({
+                "image": target,
+                "boxes": boxes,
+                "candidates": candidates,
+                "image_width": w,
+                "image_height": h,
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }, fh, indent=2)
+    elif os.path.exists(target_ann):
+        os.remove(target_ann)
+
+    return {"ok": True, "image": target,
+            "boxes": len(boxes), "candidates": len(candidates)}
+
+
+# ---------------------------------------------------------------------------
 # Classification modules (cutter_wear, wear_type) via the orchestrator
 # ---------------------------------------------------------------------------
 class ClassifyPredictRequest(BaseModel):
@@ -356,7 +512,7 @@ def api_classify_state(module: str):
             label_dir = os.path.join(module_dir, label)
             if os.path.isdir(label_dir):
                 counts[label] = len(_list_images(label_dir))
-    images = _list_images(image_folder)
+    images = _list_active_images(image_folder)
     return {
         "module": module,
         "images": [{"name": name, "url": f"/source_files/{quote(name)}"}
@@ -404,7 +560,7 @@ def api_classify_assign(payload: ClassifyAssignRequest):
 def _collect_annotations() -> List[Dict[str, Any]]:
     """Return a list of {image, path, width, height, boxes} for all annotated images."""
     results = []
-    for name in _list_images(image_folder):
+    for name in _list_active_images(image_folder):
         ann_path = _annotation_path(name)
         if not os.path.exists(ann_path):
             continue

--- a/orchestrator_client.py
+++ b/orchestrator_client.py
@@ -1,0 +1,281 @@
+"""Client for the dg-models-orchestrator service.
+
+All model inference from this app goes through the orchestrator instead of
+hitting the TFServing containers directly. The orchestrator is a thin proxy:
+it returns *raw* TFServing predictions and leaves result processing to the
+client (this module).
+
+Response envelopes (checked here — errors are reported in-band with HTTP 200):
+
+- ``POST /cutter-detect``  -> ``{"status", "model_v1", "model_v2", "error"}``
+  ``model_v1``/``model_v2`` hold the raw TFServing response of each of the two
+  detection models. If one model fails its dict is empty and the reason is in
+  ``error`` while ``status`` stays ``"success"``; if both fail ``status`` is
+  ``"error"``.
+- ``POST /blade-crop``, ``POST /cutter-wear``, ``POST /cutter-class``
+  -> ``{"status", "predictions", "error"}`` where ``predictions`` is the raw
+  TFServing predictions array.
+
+Detection predictions use the AutoML/TF Object Detection export format:
+``detection_boxes`` (normalized ``[ymin, xmin, ymax, xmax]``) plus either
+``detection_multiclass_scores`` (per-class scores, index 0 = background) or
+``detection_scores`` + ``detection_classes``/``detection_classes_as_text``.
+
+Classification predictions carry parallel ``labels``/``scores`` arrays (with
+fallbacks for other common export key names).
+"""
+
+import base64
+import json
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+DEFAULT_ORCHESTRATOR_URL = "http://localhost:8010"
+REQUEST_TIMEOUT = 60
+CONFIG_PATH = "detect_config.json"
+
+# Class-index mapping for the cutter_detect models. Index 0 is background.
+# This matches utils/process_multi_cutters.process_cutter_data (1=nozzle,
+# 2=lost, 3=cutter, 4=ring_out).
+CUTTER_CLASS_LABELS = {1: "nozzle", 2: "lost", 3: "cutter", 4: "ring_out"}
+
+# Classification modules exposed by the app -> orchestrator endpoint.
+# "wear_type" is served by the orchestrator's /cutter-class route (the
+# wear_class TFServing model behind it classifies the wear type of a cutter).
+CLASSIFY_MODULES = {
+    "cutter_wear": "/cutter-wear",
+    "wear_type": "/cutter-class",
+}
+
+# Detection modules exposed by the app -> orchestrator endpoint.
+DETECT_MODULES = {
+    "cutter_detect": "/cutter-detect",
+    "blade_crop": "/blade-crop",
+}
+
+
+class OrchestratorError(RuntimeError):
+    """Raised when the orchestrator is unreachable or reports an error."""
+
+
+def _file_config() -> Dict[str, Any]:
+    if not os.path.exists(CONFIG_PATH):
+        return {}
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return {}
+
+
+def orchestrator_url() -> str:
+    cfg = _file_config()
+    return (
+        os.getenv("ORCHESTRATOR_URL")
+        or cfg.get("orchestrator_url")
+        or DEFAULT_ORCHESTRATOR_URL
+    ).rstrip("/")
+
+
+def _api_key() -> Optional[str]:
+    return os.getenv("ORCHESTRATOR_API_KEY") or _file_config().get("orchestrator_api_key")
+
+
+def _post(path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    url = orchestrator_url() + path
+    headers = {"Content-Type": "application/json"}
+    key = _api_key()
+    if key:
+        headers["X-API-Key"] = key
+    try:
+        resp = requests.post(url, json=payload, headers=headers, timeout=REQUEST_TIMEOUT)
+    except requests.RequestException as exc:
+        raise OrchestratorError(f"orchestrator unreachable at {url}: {exc}") from exc
+    if resp.status_code == 401:
+        raise OrchestratorError("orchestrator rejected the API key (set ORCHESTRATOR_API_KEY)")
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as exc:
+        raise OrchestratorError(f"orchestrator returned HTTP {resp.status_code}: {exc}") from exc
+    try:
+        return resp.json()
+    except ValueError as exc:
+        raise OrchestratorError("orchestrator returned a non-JSON response") from exc
+
+
+def encode_image(image_path: str) -> str:
+    with open(image_path, "rb") as fh:
+        return base64.b64encode(fh.read()).decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+def detect(
+    module: str,
+    image_path: str,
+    image_key: str,
+    img_w: int,
+    img_h: int,
+) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """Run a detection module and return (detections, warning).
+
+    Detections are dicts with pixel-space ``x``/``y``/``width``/``height``
+    plus ``label`` and ``score``, unfiltered by confidence — the caller
+    decides which are annotations and which are candidates.
+    """
+    if module not in DETECT_MODULES:
+        raise OrchestratorError(f"unknown detection module: {module}")
+
+    payload = {"image": encode_image(image_path), "key": image_key}
+    data = _post(DETECT_MODULES[module], payload)
+
+    status = data.get("status")
+    if status != "success":
+        raise OrchestratorError(data.get("error") or f"orchestrator status: {status}")
+
+    if module == "cutter_detect":
+        # Dual-model envelope; "error" may note a partial (one-model) failure.
+        warning = data.get("error")
+        predictions = []
+        for model_key in ("model_v1", "model_v2"):
+            raw = data.get(model_key) or {}
+            predictions.extend(raw.get("predictions") or [])
+        detections = []
+        for pred in predictions:
+            detections.extend(_parse_detection_prediction(pred, CUTTER_CLASS_LABELS))
+        detections = _dedupe(detections)
+    else:  # blade_crop
+        warning = data.get("error")
+        detections = []
+        for pred in data.get("predictions") or []:
+            detections.extend(_parse_detection_prediction(pred, default_label="blade"))
+        detections = _dedupe(detections)
+
+    return [_to_pixel_box(d, img_w, img_h) for d in detections], warning
+
+
+def _parse_detection_prediction(
+    pred: Dict[str, Any],
+    class_labels: Optional[Dict[int, str]] = None,
+    default_label: str = "object",
+) -> List[Dict[str, Any]]:
+    """Parse one raw TFServing detection prediction into labelled boxes."""
+    boxes = pred.get("detection_boxes") or []
+    multiclass = pred.get("detection_multiclass_scores")
+    detections: List[Dict[str, Any]] = []
+
+    if multiclass:
+        for bbox, scores in zip(boxes, multiclass):
+            # index 0 is background; take the best real class
+            best_idx, best_score = -1, 0.0
+            for idx in range(1, len(scores)):
+                if float(scores[idx]) > best_score:
+                    best_idx, best_score = idx, float(scores[idx])
+            if best_idx == -1:
+                continue
+            if class_labels:
+                label = class_labels.get(best_idx, f"class_{best_idx}")
+            else:
+                label = default_label
+            detections.append({"box": [float(v) for v in bbox],
+                               "label": label, "score": best_score})
+        return detections
+
+    scores = pred.get("detection_scores") or []
+    classes_text = pred.get("detection_classes_as_text") or []
+    classes = pred.get("detection_classes") or []
+    for i, bbox in enumerate(boxes):
+        score = float(scores[i]) if i < len(scores) else 0.0
+        if i < len(classes_text) and classes_text[i]:
+            label = str(classes_text[i])
+        elif i < len(classes):
+            idx = int(float(classes[i]))
+            label = (class_labels or {}).get(idx, default_label)
+        else:
+            label = default_label
+        detections.append({"box": [float(v) for v in bbox],
+                           "label": label, "score": score})
+    return detections
+
+
+def _iou(a: List[float], b: List[float]) -> float:
+    y_a, x_a = max(a[0], b[0]), max(a[1], b[1])
+    y_b, x_b = min(a[2], b[2]), min(a[3], b[3])
+    inter = max(y_b - y_a, 0.0) * max(x_b - x_a, 0.0)
+    if inter <= 0:
+        return 0.0
+    area_a = abs((a[2] - a[0]) * (a[3] - a[1]))
+    area_b = abs((b[2] - b[0]) * (b[3] - b[1]))
+    return inter / float(area_a + area_b - inter)
+
+
+def _dedupe(detections: List[Dict[str, Any]], iou_thresh: float = 0.5) -> List[Dict[str, Any]]:
+    """Drop overlapping same-label detections, keeping the higher score."""
+    kept: List[Dict[str, Any]] = []
+    for det in sorted(detections, key=lambda d: d["score"], reverse=True):
+        duplicate = any(
+            k["label"] == det["label"] and _iou(k["box"], det["box"]) > iou_thresh
+            for k in kept
+        )
+        if not duplicate:
+            kept.append(det)
+    return kept
+
+
+def _to_pixel_box(det: Dict[str, Any], img_w: int, img_h: int) -> Dict[str, Any]:
+    ymin, xmin, ymax, xmax = det["box"]
+    return {
+        "label": det["label"],
+        "x": xmin * img_w,
+        "y": ymin * img_h,
+        "width": (xmax - xmin) * img_w,
+        "height": (ymax - ymin) * img_h,
+        "score": det["score"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+def classify(module: str, image_path: str, image_key: str) -> Dict[str, Any]:
+    """Run a classification module and return {label, confidence, all_scores}."""
+    if module not in CLASSIFY_MODULES:
+        raise OrchestratorError(f"unknown classification module: {module}")
+
+    payload = {"image": encode_image(image_path), "key": image_key}
+    data = _post(CLASSIFY_MODULES[module], payload)
+
+    if data.get("status") != "success":
+        raise OrchestratorError(data.get("error") or f"orchestrator status: {data.get('status')}")
+
+    predictions = data.get("predictions") or []
+    if not predictions:
+        raise OrchestratorError("orchestrator returned no predictions")
+    return _parse_classification_prediction(predictions[0])
+
+
+def _parse_classification_prediction(pred: Dict[str, Any]) -> Dict[str, Any]:
+    labels = pred.get("labels") or pred.get("classes") or pred.get("display_names")
+    scores = pred.get("scores") or pred.get("probabilities") or pred.get("confidences")
+
+    if scores is None:
+        raise OrchestratorError(
+            f"unrecognized classification prediction format (keys: {sorted(pred.keys())})")
+
+    scores = [float(s) for s in scores]
+    if labels is None:
+        labels = [f"class_{i}" for i in range(len(scores))]
+    labels = [str(l) for l in labels]
+
+    all_scores = dict(zip(labels, scores))
+    if not all_scores:
+        raise OrchestratorError("classification prediction contained no scores")
+    best_label = max(all_scores, key=all_scores.get)
+    return {
+        "label": best_label,
+        "confidence": all_scores[best_label],
+        "all_scores": all_scores,
+    }

--- a/orchestrator_client.py
+++ b/orchestrator_client.py
@@ -26,11 +26,13 @@ fallbacks for other common export key names).
 """
 
 import base64
+import io
 import json
 import os
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
+from PIL import Image, ImageOps
 
 DEFAULT_ORCHESTRATOR_URL = "http://localhost:8010"
 REQUEST_TIMEOUT = 60
@@ -106,8 +108,28 @@ def _post(path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def encode_image(image_path: str) -> str:
+    """Base64-encode an image for inference, normalizing EXIF orientation.
+
+    Cameras often store rotated pixels plus an EXIF orientation tag. Browsers
+    render the *oriented* image, but TFServing models decode the raw pixels —
+    so an image with a non-default orientation must be transposed before
+    inference or the returned boxes land in the wrong place on screen.
+    """
     with open(image_path, "rb") as fh:
-        return base64.b64encode(fh.read()).decode("utf-8")
+        raw = fh.read()
+    try:
+        with Image.open(io.BytesIO(raw)) as img:
+            orientation = img.getexif().get(0x0112, 1)
+            if orientation and int(orientation) != 1:
+                oriented = ImageOps.exif_transpose(img)
+                if oriented.mode != "RGB":
+                    oriented = oriented.convert("RGB")
+                buf = io.BytesIO()
+                oriented.save(buf, format="JPEG", quality=95)
+                return base64.b64encode(buf.getvalue()).decode("utf-8")
+    except Exception:
+        pass  # unreadable metadata: fall through and send the bytes as stored
+    return base64.b64encode(raw).decode("utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/static/classify.js
+++ b/static/classify.js
@@ -1,0 +1,260 @@
+// Model-assisted classification UI.
+//
+// A module (cutter_wear / wear_type) is a classification model served by the
+// dg-models-orchestrator. The model suggests a label with per-class scores;
+// clicking a label moves the image into sorted_files/<module>/<label>/ and
+// advances to the next image. The prediction is only a suggestion — nothing
+// is saved until the user clicks.
+
+const el = (id) => document.getElementById(id);
+
+const state = {
+    images: [],       // [{name, url}]
+    counts: {},       // {label: n} for the active module
+    current: null,
+    prediction: null, // {label, confidence, all_scores}
+    predictSeq: 0,    // guards against out-of-order prediction responses
+};
+
+let toastTimer = null;
+function toast(msg, isError = false) {
+    const t = el("toast");
+    t.textContent = msg;
+    t.classList.toggle("error", !!isError);
+    t.classList.add("show");
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => t.classList.remove("show"), 2600);
+}
+
+function activeModule() {
+    return el("module-select").value;
+}
+
+// ---------------------------------------------------------------------------
+// State loading / image list
+// ---------------------------------------------------------------------------
+async function loadState(keepCurrent = false) {
+    const res = await fetch(`/api/classify/state?module=${encodeURIComponent(activeModule())}`);
+    if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast(err.detail || "Failed to load state", true);
+        return;
+    }
+    const data = await res.json();
+    state.images = data.images;
+    state.counts = data.counts;
+    renderCounts();
+    renderImageList();
+    el("progress").textContent = `${data.remaining} remaining`;
+
+    const stillThere = keepCurrent && state.current &&
+        state.images.some((i) => i.name === state.current.name);
+    if (!stillThere) {
+        selectImage(state.images.length ? state.images[0] : null);
+    }
+}
+
+function renderImageList() {
+    const filter = el("image-filter").value.trim().toLowerCase();
+    const list = el("image-list");
+    list.innerHTML = "";
+    state.images
+        .filter((img) => !filter || img.name.toLowerCase().includes(filter))
+        .forEach((img) => {
+            const li = document.createElement("li");
+            li.textContent = img.name;
+            if (state.current && state.current.name === img.name) {
+                li.classList.add("active");
+            }
+            li.addEventListener("click", () => selectImage(img));
+            list.appendChild(li);
+        });
+}
+
+function renderCounts() {
+    const table = el("counts-table");
+    table.innerHTML = "";
+    const labels = Object.keys(state.counts).sort();
+    if (!labels.length) {
+        table.innerHTML = "<tr><td class='hint-text'>Nothing sorted yet.</td></tr>";
+        return;
+    }
+    labels.forEach((label) => {
+        const tr = document.createElement("tr");
+        const name = document.createElement("td");
+        name.textContent = label;
+        const count = document.createElement("td");
+        count.textContent = state.counts[label];
+        tr.appendChild(name);
+        tr.appendChild(count);
+        table.appendChild(tr);
+    });
+}
+
+function selectImage(img) {
+    state.current = img;
+    state.prediction = null;
+    state.predictSeq++;
+    el("current-image").textContent = img ? img.name : "—";
+    el("source-image").src = img ? img.url : "";
+    renderImageList();
+    renderPrediction();
+    if (img && el("auto-predict").checked) predict();
+}
+
+function nextImage(delta) {
+    if (!state.current || !state.images.length) return;
+    const idx = state.images.findIndex((i) => i.name === state.current.name);
+    const nextIdx = (idx + delta + state.images.length) % state.images.length;
+    selectImage(state.images[nextIdx]);
+}
+
+// ---------------------------------------------------------------------------
+// Prediction
+// ---------------------------------------------------------------------------
+async function predict() {
+    if (!state.current) return;
+    const seq = ++state.predictSeq;
+    const btn = el("predict-btn");
+    btn.disabled = true;
+    el("prediction-title").textContent = "Prediction — asking model…";
+    try {
+        const res = await fetch("/api/classify/predict", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ image: state.current.name, module: activeModule() }),
+        });
+        if (seq !== state.predictSeq) return; // user moved on
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            toast(err.detail || "Prediction failed", true);
+            el("prediction-title").textContent = "Prediction — failed";
+            return;
+        }
+        state.prediction = await res.json();
+        if (seq !== state.predictSeq) return;
+        renderPrediction();
+    } catch (exc) {
+        if (seq === state.predictSeq) {
+            toast("Prediction failed: " + exc, true);
+            el("prediction-title").textContent = "Prediction — failed";
+        }
+    } finally {
+        btn.disabled = false;
+    }
+}
+
+function renderPrediction() {
+    const rows = el("score-rows");
+    rows.innerHTML = "";
+    if (!state.prediction) {
+        el("prediction-title").textContent = "Prediction";
+        return;
+    }
+    const p = state.prediction;
+    el("prediction-title").textContent =
+        `Prediction: ${p.label} (${(p.confidence * 100).toFixed(1)}%)`;
+
+    Object.entries(p.all_scores)
+        .sort((a, b) => b[1] - a[1])
+        .forEach(([label, score]) => {
+            const row = document.createElement("div");
+            row.className = "score-row";
+
+            const btn = document.createElement("button");
+            btn.className = "label-btn" + (label === p.label ? " top" : "");
+            btn.textContent = label;
+            btn.title = `Move image to sorted_files/${activeModule()}/${label}/`;
+            btn.addEventListener("click", () => assign(label));
+            row.appendChild(btn);
+
+            const track = document.createElement("div");
+            track.className = "score-bar-track";
+            const bar = document.createElement("div");
+            bar.className = "score-bar";
+            bar.style.width = `${Math.max(1, score * 100)}%`;
+            track.appendChild(bar);
+            row.appendChild(track);
+
+            const val = document.createElement("span");
+            val.className = "score-val";
+            val.textContent = `${(score * 100).toFixed(1)}%`;
+            row.appendChild(val);
+
+            rows.appendChild(row);
+        });
+}
+
+// ---------------------------------------------------------------------------
+// Assignment
+// ---------------------------------------------------------------------------
+async function assign(label) {
+    if (!state.current) return;
+    const res = await fetch("/api/classify/assign", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            image: state.current.name,
+            module: activeModule(),
+            label,
+        }),
+    });
+    if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast(err.detail || "Assign failed", true);
+        return;
+    }
+    const data = await res.json();
+    toast(`Moved to ${data.module}/${data.label}`);
+    state.current = null;
+    await loadState();
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+el("predict-btn").addEventListener("click", predict);
+el("prev-btn").addEventListener("click", () => nextImage(-1));
+el("next-btn").addEventListener("click", () => nextImage(1));
+el("image-filter").addEventListener("input", renderImageList);
+el("module-select").addEventListener("change", () => loadState(true).then(() => {
+    state.prediction = null;
+    renderPrediction();
+    if (state.current && el("auto-predict").checked) predict();
+}));
+el("custom-assign-btn").addEventListener("click", () => {
+    const label = el("custom-label").value.trim();
+    if (!label) { toast("Enter a label first", true); return; }
+    assign(label);
+});
+el("custom-label").addEventListener("keydown", (e) => {
+    if (e.key === "Enter") el("custom-assign-btn").click();
+});
+
+window.addEventListener("keydown", (e) => {
+    if (e.target.tagName === "INPUT" || e.target.tagName === "SELECT") return;
+    if (e.key === "ArrowRight") nextImage(1);
+    else if (e.key === "ArrowLeft") nextImage(-1);
+});
+
+el("upload-input").addEventListener("change", async function () {
+    const form = new FormData();
+    for (const file of this.files) form.append("files", file);
+    const status = el("upload-status");
+    status.textContent = "Uploading…";
+    try {
+        const res = await fetch("/upload", { method: "POST", body: form });
+        const data = await res.json();
+        if (res.ok) {
+            status.textContent = `✓ Uploaded ${data.uploaded.length} file(s).`;
+            await loadState(true);
+        } else {
+            status.textContent = `Error: ${data.detail}`;
+        }
+    } catch (e) { status.textContent = "Upload failed."; }
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+loadState();

--- a/static/detect.css
+++ b/static/detect.css
@@ -221,10 +221,36 @@ html, body {
     border-radius: 3px;
     font-size: 12px;
 }
-#box-list .remove {
+#box-list .remove,
+#candidate-list .remove {
     background: transparent;
     border: none;
     color: #b91c1c;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+#box-list li.rejected { opacity: 0.55; }
+#box-list li.rejected input { text-decoration: line-through; }
+
+#candidate-list { list-style: none; padding: 0; margin: 0; }
+#candidate-list li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    background: #fffbeb;
+    border: 1px dashed #f59e0b55;
+    margin-bottom: 3px;
+}
+#candidate-list li:hover { background: #fef3c7; }
+#candidate-list .accept {
+    background: transparent;
+    border: none;
+    color: #15803d;
     cursor: pointer;
     font-size: 14px;
 }

--- a/static/detect.js
+++ b/static/detect.js
@@ -1,11 +1,19 @@
 // Object detection labeling UI.
 //
 // State model
-//   state.images   : [{name, url, annotated}]
-//   state.current  : image object we're labeling
-//   state.boxes    : [{label, x, y, width, height, score?}] in image pixel space
-//   state.selected : index of selected box or -1
-//   state.imgW/H   : natural dimensions of the current image
+//   state.images     : [{name, url, annotated}]
+//   state.current    : image object we're labeling
+//   state.boxes      : [{label, x, y, width, height, score?, rejected?}]
+//                      in image pixel space. A box with a score is a model
+//                      detection: clicking it toggles rejected (rejected
+//                      boxes are not saved). Boxes without a score are
+//                      hand-drawn: clicking selects them.
+//   state.candidates : [{label, x, y, width, height, score}] low-confidence
+//                      model detections (candidate band, default 20-50%).
+//                      Clicking one accepts it into state.boxes; unaccepted
+//                      candidates are ignored by every export.
+//   state.selected   : index of selected box or -1
+//   state.imgW/H     : natural dimensions of the current image
 //
 // The canvas is drawn on top of the image; we maintain an image -> canvas
 // scale factor so that boxes are stored in image pixel coordinates (which is
@@ -17,6 +25,7 @@ const state = {
     images: [],
     current: null,
     boxes: [],
+    candidates: [],
     selected: -1,
     imgW: 0,
     imgH: 0,
@@ -105,6 +114,7 @@ function updateProgress() {
 async function selectImage(img) {
     state.current = img;
     state.boxes = [];
+    state.candidates = [];
     state.selected = -1;
     state.dirty = false;
     el("current-image").textContent = img.name;
@@ -113,6 +123,7 @@ async function selectImage(img) {
     const res = await fetch(`/api/detect/annotation/${encodeURIComponent(img.name)}`);
     const data = await res.json();
     state.boxes = (data.boxes || []).map((b) => ({ ...b }));
+    state.candidates = (data.candidates || []).map((b) => ({ ...b }));
     state.imgW = data.image_width || 0;
     state.imgH = data.image_height || 0;
 
@@ -172,18 +183,44 @@ function drawBoxes() {
     const c = canvas();
     const g = ctx();
     g.clearRect(0, 0, c.width, c.height);
-    state.boxes.forEach((box, idx) => {
-        const selected = idx === state.selected;
-        const color = colorFor(box.label);
-        g.lineWidth = selected ? 3 : 2;
-        g.strokeStyle = color;
-        g.fillStyle = color + "22";
+
+    // Candidates first, dashed, so accepted boxes draw on top of them.
+    state.candidates.forEach((box) => {
         const x = toCanvas(box.x), y = toCanvas(box.y);
         const w = toCanvas(box.width), h = toCanvas(box.height);
+        g.lineWidth = 2;
+        g.setLineDash([6, 4]);
+        g.strokeStyle = "#f59e0b";
+        g.fillStyle = "#f59e0b18";
         g.fillRect(x, y, w, h);
         g.strokeRect(x, y, w, h);
+        g.setLineDash([]);
 
-        const label = box.label + (box.score != null ? ` ${(box.score * 100).toFixed(0)}%` : "");
+        const label = `? ${box.label} ${(box.score * 100).toFixed(0)}%`;
+        g.font = "12px sans-serif";
+        const metrics = g.measureText(label);
+        g.fillStyle = "#f59e0b";
+        g.fillRect(x, y - 16, metrics.width + 8, 16);
+        g.fillStyle = "#fff";
+        g.fillText(label, x + 4, y - 4);
+    });
+
+    state.boxes.forEach((box, idx) => {
+        const selected = idx === state.selected;
+        const rejected = !!box.rejected;
+        const color = rejected ? "#9ca3af" : colorFor(box.label);
+        g.lineWidth = selected ? 3 : 2;
+        g.strokeStyle = color;
+        g.fillStyle = rejected ? "#9ca3af10" : color + "22";
+        const x = toCanvas(box.x), y = toCanvas(box.y);
+        const w = toCanvas(box.width), h = toCanvas(box.height);
+        if (rejected) g.setLineDash([3, 3]);
+        g.fillRect(x, y, w, h);
+        g.strokeRect(x, y, w, h);
+        g.setLineDash([]);
+
+        const label = (rejected ? "✕ " : "") + box.label +
+            (box.score != null ? ` ${(box.score * 100).toFixed(0)}%` : "");
         g.font = "12px sans-serif";
         const metrics = g.measureText(label);
         const labelH = 16;
@@ -191,6 +228,14 @@ function drawBoxes() {
         g.fillRect(x, y - labelH, metrics.width + 8, labelH);
         g.fillStyle = "#fff";
         g.fillText(label, x + 4, y - 4);
+        if (rejected) {
+            g.strokeStyle = color;
+            g.lineWidth = 1.5;
+            g.beginPath();
+            g.moveTo(x, y); g.lineTo(x + w, y + h);
+            g.moveTo(x + w, y); g.lineTo(x, y + h);
+            g.stroke();
+        }
     });
 
     updateColorSwatch();
@@ -223,13 +268,53 @@ function hitTest(pt) {
     return -1;
 }
 
+function hitTestCandidates(pt) {
+    for (let i = state.candidates.length - 1; i >= 0; i--) {
+        const b = state.candidates[i];
+        const x = toCanvas(b.x), y = toCanvas(b.y);
+        const w = toCanvas(b.width), h = toCanvas(b.height);
+        if (pt.x >= x && pt.x <= x + w && pt.y >= y && pt.y <= y + h) return i;
+    }
+    return -1;
+}
+
+function acceptCandidate(idx) {
+    const cand = state.candidates.splice(idx, 1)[0];
+    state.boxes.push({ ...cand });
+    state.selected = state.boxes.length - 1;
+    state.dirty = true;
+    drawBoxes();
+    renderBoxList();
+    toast(`Accepted candidate "${cand.label}"`);
+}
+
+function toggleReject(idx) {
+    const box = state.boxes[idx];
+    box.rejected = !box.rejected;
+    state.selected = box.rejected ? -1 : idx;
+    state.dirty = true;
+    drawBoxes();
+    renderBoxList();
+}
+
 canvas().addEventListener("mousedown", (e) => {
     const pt = canvasPoint(e);
     const hit = hitTest(pt);
     if (hit !== -1) {
-        state.selected = hit;
-        drawBoxes();
-        renderBoxList();
+        const box = state.boxes[hit];
+        if (box.score != null) {
+            // Model detection: a click rejects it (clicking again restores).
+            toggleReject(hit);
+        } else {
+            state.selected = hit;
+            drawBoxes();
+            renderBoxList();
+        }
+        return;
+    }
+    const candHit = hitTestCandidates(pt);
+    if (candHit !== -1) {
+        acceptCandidate(candHit);
         return;
     }
     dragging = true;
@@ -313,19 +398,22 @@ window.addEventListener("keydown", (e) => {
 function renderBoxList() {
     const list = el("box-list");
     list.innerHTML = "";
-    el("box-count").textContent = `(${state.boxes.length})`;
+    const active = state.boxes.filter((b) => !b.rejected).length;
+    el("box-count").textContent = `(${active})`;
     state.boxes.forEach((box, idx) => {
         const li = document.createElement("li");
         if (idx === state.selected) li.classList.add("selected");
+        if (box.rejected) li.classList.add("rejected");
 
         const swatch = document.createElement("span");
         swatch.className = "swatch";
-        swatch.style.background = colorFor(box.label);
+        swatch.style.background = box.rejected ? "#9ca3af" : colorFor(box.label);
         li.appendChild(swatch);
 
         const input = document.createElement("input");
         input.type = "text";
         input.value = box.label;
+        input.disabled = !!box.rejected;
         input.addEventListener("change", () => {
             box.label = input.value.trim() || "object";
             state.dirty = true;
@@ -339,6 +427,15 @@ function renderBoxList() {
             score.style.fontSize = "11px";
             score.style.color = "#6b7280";
             li.appendChild(score);
+        }
+
+        if (box.score != null) {
+            const rejectBtn = document.createElement("button");
+            rejectBtn.className = "remove";
+            rejectBtn.textContent = box.rejected ? "↩" : "⊘";
+            rejectBtn.title = box.rejected ? "Restore detection" : "Reject detection (not saved)";
+            rejectBtn.addEventListener("click", () => toggleReject(idx));
+            li.appendChild(rejectBtn);
         }
 
         const remove = document.createElement("button");
@@ -355,10 +452,64 @@ function renderBoxList() {
         li.appendChild(remove);
 
         li.addEventListener("click", (e) => {
-            if (e.target === remove || e.target === input) return;
+            if (e.target.tagName === "BUTTON" || e.target === input) return;
             state.selected = idx;
             drawBoxes();
             renderBoxList();
+        });
+
+        list.appendChild(li);
+    });
+
+    renderCandidateList();
+}
+
+function renderCandidateList() {
+    const list = el("candidate-list");
+    list.innerHTML = "";
+    el("candidate-count").textContent = `(${state.candidates.length})`;
+    state.candidates.forEach((cand, idx) => {
+        const li = document.createElement("li");
+        li.classList.add("candidate");
+
+        const swatch = document.createElement("span");
+        swatch.className = "swatch";
+        swatch.style.background = "#f59e0b";
+        li.appendChild(swatch);
+
+        const name = document.createElement("span");
+        name.textContent = cand.label;
+        name.style.flex = "1";
+        li.appendChild(name);
+
+        const score = document.createElement("span");
+        score.textContent = `${(cand.score * 100).toFixed(0)}%`;
+        score.style.fontSize = "11px";
+        score.style.color = "#92400e";
+        li.appendChild(score);
+
+        const accept = document.createElement("button");
+        accept.className = "accept";
+        accept.textContent = "✓";
+        accept.title = "Accept into annotation set";
+        accept.addEventListener("click", () => acceptCandidate(idx));
+        li.appendChild(accept);
+
+        const dismiss = document.createElement("button");
+        dismiss.className = "remove";
+        dismiss.textContent = "✕";
+        dismiss.title = "Dismiss candidate";
+        dismiss.addEventListener("click", () => {
+            state.candidates.splice(idx, 1);
+            state.dirty = true;
+            drawBoxes();
+            renderBoxList();
+        });
+        li.appendChild(dismiss);
+
+        li.addEventListener("click", (e) => {
+            if (e.target.tagName === "BUTTON") return;
+            acceptCandidate(idx);
         });
 
         list.appendChild(li);
@@ -389,9 +540,14 @@ el("active-label").addEventListener("input", updateColorSwatch);
 // ---------------------------------------------------------------------------
 async function saveAnnotation() {
     if (!state.current) return;
+    // Rejected detections are dropped; unaccepted candidates are stored
+    // separately so they persist but never reach an export.
     const payload = {
         image: state.current.name,
-        boxes: state.boxes,
+        boxes: state.boxes
+            .filter((b) => !b.rejected)
+            .map(({ rejected, ...b }) => b),
+        candidates: state.candidates,
         image_width: state.imgW,
         image_height: state.imgH,
     };
@@ -413,9 +569,10 @@ async function saveAnnotation() {
 }
 
 function clearAll() {
-    if (!state.boxes.length) return;
-    if (!confirm("Remove all boxes on this image?")) return;
+    if (!state.boxes.length && !state.candidates.length) return;
+    if (!confirm("Remove all boxes and candidates on this image?")) return;
     state.boxes = [];
+    state.candidates = [];
     state.selected = -1;
     state.dirty = true;
     drawBoxes();
@@ -452,8 +609,9 @@ el("auto-annotate-btn").addEventListener("click", async () => {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
                 image: state.current.name,
-                endpoint: el("endpoint").value.trim() || null,
+                module: el("auto-module").value,
                 threshold: parseFloat(el("auto-threshold").value) || 0.5,
+                candidate_threshold: parseFloat(el("candidate-threshold").value) || 0.2,
             }),
         });
         if (!res.ok) {
@@ -462,12 +620,15 @@ el("auto-annotate-btn").addEventListener("click", async () => {
             return;
         }
         const data = await res.json();
-        // Merge suggested boxes with existing ones so the user can edit.
+        // Merge suggested boxes with existing ones so the user can edit;
+        // candidates from this run replace the previous candidate set.
         data.boxes.forEach((b) => state.boxes.push(b));
+        state.candidates = data.candidates || [];
         state.dirty = true;
         drawBoxes();
         renderBoxList();
-        toast(`Added ${data.boxes.length} suggested boxes`);
+        const msg = `Added ${data.boxes.length} boxes, ${state.candidates.length} candidates`;
+        toast(data.warning ? `${msg} — ${data.warning}` : msg, !!data.warning);
     } catch (exc) {
         toast("Auto-annotate failed: " + exc, true);
     } finally {

--- a/static/detect.js
+++ b/static/detect.js
@@ -97,10 +97,7 @@ function renderImageList() {
             if (state.current && state.current.name === img.name) {
                 li.classList.add("active");
             }
-            li.addEventListener("click", () => {
-                if (state.dirty && !confirm("Discard unsaved changes?")) return;
-                selectImage(img);
-            });
+            li.addEventListener("click", () => selectImage(img));
             list.appendChild(li);
         });
     updateProgress();
@@ -570,7 +567,6 @@ async function saveAnnotation() {
 
 function clearAll() {
     if (!state.boxes.length && !state.candidates.length) return;
-    if (!confirm("Remove all boxes and candidates on this image?")) return;
     state.boxes = [];
     state.candidates = [];
     state.selected = -1;
@@ -581,7 +577,6 @@ function clearAll() {
 
 function nextImage(delta) {
     if (!state.current) return;
-    if (state.dirty && !confirm("Discard unsaved changes?")) return;
     const idx = state.images.findIndex((i) => i.name === state.current.name);
     const nextIdx = (idx + delta + state.images.length) % state.images.length;
     selectImage(state.images[nextIdx]);
@@ -690,16 +685,6 @@ el("gcp-export-btn").addEventListener("click", async () => {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-});
-
-// ---------------------------------------------------------------------------
-// Warn on unload if dirty
-// ---------------------------------------------------------------------------
-window.addEventListener("beforeunload", (e) => {
-    if (state.dirty) {
-        e.preventDefault();
-        e.returnValue = "";
-    }
 });
 
 // ---------------------------------------------------------------------------

--- a/static/detect.js
+++ b/static/detect.js
@@ -97,7 +97,10 @@ function renderImageList() {
             if (state.current && state.current.name === img.name) {
                 li.classList.add("active");
             }
-            li.addEventListener("click", () => selectImage(img));
+            li.addEventListener("click", async () => {
+                await autoSaveIfDirty();
+                selectImage(img);
+            });
             list.appendChild(li);
         });
     updateProgress();
@@ -114,6 +117,7 @@ async function selectImage(img) {
     state.candidates = [];
     state.selected = -1;
     state.dirty = false;
+    if (cropMode) setCropMode(false);
     el("current-image").textContent = img.name;
 
     // Load annotation
@@ -235,6 +239,22 @@ function drawBoxes() {
         }
     });
 
+    // Crop overlay: dim everything outside the selected region.
+    if (cropMode && state.cropRect) {
+        const x = toCanvas(state.cropRect.x), y = toCanvas(state.cropRect.y);
+        const w = toCanvas(state.cropRect.width), h = toCanvas(state.cropRect.height);
+        g.fillStyle = "rgba(15, 23, 42, 0.55)";
+        g.fillRect(0, 0, c.width, y);
+        g.fillRect(0, y + h, c.width, c.height - y - h);
+        g.fillRect(0, y, x, h);
+        g.fillRect(x + w, y, c.width - x - w, h);
+        g.strokeStyle = "#fff";
+        g.setLineDash([6, 4]);
+        g.lineWidth = 2;
+        g.strokeRect(x, y, w, h);
+        g.setLineDash([]);
+    }
+
     updateColorSwatch();
 }
 
@@ -246,6 +266,11 @@ function updateColorSwatch() {
 let dragging = false;
 let dragStart = null;
 let dragBox = null;  // the in-progress box in image coordinates
+
+// Crop state (crop mode repurposes the drag gesture to pick a region)
+let cropMode = false;
+let cropDragging = false;
+let cropStart = null;
 
 function canvasPoint(evt) {
     const rect = canvas().getBoundingClientRect();
@@ -296,6 +321,13 @@ function toggleReject(idx) {
 
 canvas().addEventListener("mousedown", (e) => {
     const pt = canvasPoint(e);
+    if (cropMode) {
+        cropDragging = true;
+        cropStart = pt;
+        state.cropRect = null;
+        drawBoxes();
+        return;
+    }
     const hit = hitTest(pt);
     if (hit !== -1) {
         const box = state.boxes[hit];
@@ -321,6 +353,19 @@ canvas().addEventListener("mousedown", (e) => {
 });
 
 canvas().addEventListener("mousemove", (e) => {
+    if (cropDragging) {
+        const pt = canvasPoint(e);
+        const x1 = Math.min(cropStart.x, pt.x), y1 = Math.min(cropStart.y, pt.y);
+        const x2 = Math.max(cropStart.x, pt.x), y2 = Math.max(cropStart.y, pt.y);
+        state.cropRect = {
+            x: toImage(x1),
+            y: toImage(y1),
+            width: toImage(x2 - x1),
+            height: toImage(y2 - y1),
+        };
+        drawBoxes();
+        return;
+    }
     if (!dragging) return;
     const pt = canvasPoint(e);
     const x1 = Math.min(dragStart.x, pt.x);
@@ -344,6 +389,15 @@ canvas().addEventListener("mousemove", (e) => {
 });
 
 window.addEventListener("mouseup", (e) => {
+    if (cropDragging) {
+        cropDragging = false;
+        if (!state.cropRect || state.cropRect.width < 8 || state.cropRect.height < 8) {
+            state.cropRect = null;
+        }
+        updateCropButtons();
+        drawBoxes();
+        return;
+    }
     if (!dragging) return;
     dragging = false;
     if (dragBox && dragBox.width > 3 && dragBox.height > 3) {
@@ -358,6 +412,7 @@ window.addEventListener("mouseup", (e) => {
 });
 
 canvas().addEventListener("dblclick", (e) => {
+    if (cropMode) return;
     const pt = canvasPoint(e);
     const hit = hitTest(pt);
     if (hit === -1) return;
@@ -372,6 +427,10 @@ canvas().addEventListener("dblclick", (e) => {
 
 window.addEventListener("keydown", (e) => {
     if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
+    if (e.key === "Escape" && cropMode) {
+        setCropMode(false);
+        return;
+    }
     if ((e.key === "Delete" || e.key === "Backspace") && state.selected !== -1) {
         state.boxes.splice(state.selected, 1);
         state.selected = -1;
@@ -535,7 +594,7 @@ el("active-label").addEventListener("input", updateColorSwatch);
 // ---------------------------------------------------------------------------
 // Save / clear / navigation
 // ---------------------------------------------------------------------------
-async function saveAnnotation() {
+async function saveAnnotation(silent = false) {
     if (!state.current) return;
     // Rejected detections are dropped; unaccepted candidates are stored
     // separately so they persist but never reach an export.
@@ -560,9 +619,13 @@ async function saveAnnotation() {
     const data = await res.json();
     state.dirty = false;
     state.current.annotated = true;
-    toast(`Saved ${data.saved} boxes`);
+    if (!silent) toast(`Saved ${data.saved} boxes`);
     renderImageList();
     refreshLabelSuggestions();
+}
+
+async function autoSaveIfDirty() {
+    if (state.dirty && state.current) await saveAnnotation(true);
 }
 
 function clearAll() {
@@ -575,9 +638,11 @@ function clearAll() {
     renderBoxList();
 }
 
-function nextImage(delta) {
+async function nextImage(delta) {
     if (!state.current) return;
-    const idx = state.images.findIndex((i) => i.name === state.current.name);
+    const name = state.current.name;
+    await autoSaveIfDirty();
+    const idx = state.images.findIndex((i) => i.name === name);
     const nextIdx = (idx + delta + state.images.length) % state.images.length;
     selectImage(state.images[nextIdx]);
 }
@@ -630,6 +695,57 @@ el("auto-annotate-btn").addEventListener("click", async () => {
         btn.textContent = prev;
         btn.disabled = false;
     }
+});
+
+// ---------------------------------------------------------------------------
+// Image editing (crop / rotate)
+//
+// Edits are applied server-side and saved as an edited copy in the same
+// folder; the original stays on disk but leaves the image list unless it has
+// saved boxes. Saved boxes/candidates are remapped onto the edited image.
+// ---------------------------------------------------------------------------
+function setCropMode(on) {
+    cropMode = on;
+    cropDragging = false;
+    state.cropRect = null;
+    el("crop-btn").classList.toggle("primary", on);
+    updateCropButtons();
+    drawBoxes();
+}
+
+function updateCropButtons() {
+    el("crop-apply-btn").hidden = !(cropMode && state.cropRect);
+    el("crop-cancel-btn").hidden = !cropMode;
+}
+
+async function applyEdit(edit) {
+    if (!state.current) return;
+    await autoSaveIfDirty();
+    const res = await fetch("/api/detect/edit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ image: state.current.name, ...edit }),
+    });
+    if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast(err.detail || "Edit failed", true);
+        return;
+    }
+    const data = await res.json();
+    setCropMode(false);
+    await loadImages();
+    const img = state.images.find((i) => i.name === data.image);
+    if (img) await selectImage(img);
+    toast(`Saved edited image ${data.image}`);
+}
+
+el("rotate-cw-btn").addEventListener("click", () => applyEdit({ rotate: 90 }));
+el("rotate-ccw-btn").addEventListener("click", () => applyEdit({ rotate: -90 }));
+el("crop-btn").addEventListener("click", () => setCropMode(!cropMode));
+el("crop-cancel-btn").addEventListener("click", () => setCropMode(false));
+el("crop-apply-btn").addEventListener("click", () => {
+    if (!state.cropRect) return;
+    applyEdit({ crop: state.cropRect });
 });
 
 // ---------------------------------------------------------------------------

--- a/templates/classify.html
+++ b/templates/classify.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Model-Assisted Classifier</title>
+    <link rel="stylesheet" href="/static/detect.css">
+    <style>
+        .classify-stage {
+            flex: 1;
+            min-height: 300px;
+            background: #0f172a;
+            border-radius: 6px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+        }
+        .classify-stage img { max-width: 100%; max-height: 100%; }
+        .prediction-panel { margin-top: 10px; }
+        .score-row {
+            display: flex; align-items: center; gap: 8px; margin-bottom: 6px;
+        }
+        .score-row button.label-btn {
+            min-width: 130px; text-align: left;
+        }
+        .score-row button.label-btn.top {
+            background: #4f46e5; color: #fff; border-color: #4338ca;
+        }
+        .score-bar-track {
+            flex: 1; height: 8px; border-radius: 4px; background: #e5e7eb;
+            overflow: hidden;
+        }
+        .score-bar { height: 100%; background: #4f46e5; }
+        .score-val { width: 48px; font-size: 12px; color: #374151; text-align: right; }
+        .counts-table { width: 100%; font-size: 13px; border-collapse: collapse; }
+        .counts-table td { padding: 3px 4px; border-bottom: 1px solid #f3f4f6; }
+        .counts-table td:last-child { text-align: right; color: #6b7280; }
+    </style>
+</head>
+<body>
+    <header class="topbar">
+        <div class="brand">
+            <strong>img_move_label</strong>
+            <nav>
+                <a href="/">Classifier</a>
+                <a href="/classify" class="active">Model Classify</a>
+                <a href="/detect">Object Detection</a>
+            </nav>
+        </div>
+        <div class="stats">
+            <span id="progress">—</span>
+        </div>
+    </header>
+
+    <main class="layout">
+        <aside class="sidebar">
+            <h3>Images</h3>
+            <input type="text" id="image-filter" placeholder="Filter by name…">
+            <ul id="image-list"></ul>
+        </aside>
+
+        <section class="workspace">
+            <div class="toolbar">
+                <button id="prev-btn" title="Previous (Left Arrow)">◀ Prev</button>
+                <span id="current-image">—</span>
+                <button id="next-btn" title="Next (Right Arrow)">Next ▶</button>
+
+                <span class="divider"></span>
+
+                <label title="Classification model served by the orchestrator">
+                    Module
+                    <select id="module-select">
+                        {% for m in modules %}
+                        <option value="{{m}}">{{m}}</option>
+                        {% endfor %}
+                    </select>
+                </label>
+
+                <button id="predict-btn">✨ Predict</button>
+                <label class="checkbox" style="font-weight:normal;">
+                    <input type="checkbox" id="auto-predict" checked>
+                    Auto-predict
+                </label>
+            </div>
+
+            <div class="classify-stage">
+                <img id="source-image" alt="">
+            </div>
+
+            <div class="prediction-panel">
+                <h4 id="prediction-title">Prediction</h4>
+                <div id="score-rows"></div>
+                <div class="score-row">
+                    <input type="text" id="custom-label" placeholder="Custom label…"
+                           style="min-width:130px;padding:4px 6px;border:1px solid #d1d5db;border-radius:4px;font-size:13px;">
+                    <button id="custom-assign-btn">Assign</button>
+                    <span class="hint-text">Click a label to move the image to
+                        <code>sorted_files/&lt;module&gt;/&lt;label&gt;/</code> and advance.</span>
+                </div>
+            </div>
+        </section>
+
+        <aside class="rightbar">
+            <section>
+                <h3>Sorted so far</h3>
+                <table class="counts-table" id="counts-table"></table>
+            </section>
+
+            <section>
+                <h3>Upload images</h3>
+                <label for="upload-input" style="display:inline-block;background:#16a34a;color:#fff;padding:6px 12px;border-radius:4px;font-size:13px;cursor:pointer;">
+                    ⬆ Upload Images
+                </label>
+                <input id="upload-input" type="file" accept="image/*" multiple style="display:none;">
+                <p id="upload-status" class="hint-text"></p>
+            </section>
+
+            <section>
+                <h3>About</h3>
+                <p class="hint-text">
+                    Predictions come from the dg-models-orchestrator:
+                    <strong>cutter_wear</strong> uses <code>/cutter-wear</code>,
+                    <strong>wear_type</strong> uses <code>/cutter-class</code>.
+                    The model only suggests — the label you click is what gets saved.
+                </p>
+            </section>
+        </aside>
+    </main>
+
+    <div id="toast" class="toast"></div>
+
+    <script src="/static/classify.js"></script>
+</body>
+</html>

--- a/templates/detect.html
+++ b/templates/detect.html
@@ -12,6 +12,7 @@
             <strong>img_move_label</strong>
             <nav>
                 <a href="/">Classifier</a>
+                <a href="/classify">Model Classify</a>
                 <a href="/detect" class="active">Object Detection</a>
             </nav>
         </div>
@@ -48,12 +49,23 @@
 
                 <span class="divider"></span>
 
-                <button id="auto-annotate-btn" title="Ask the configured model for boxes">
+                <label title="Detection model served by the orchestrator">
+                    Model
+                    <select id="auto-module">
+                        <option value="cutter_detect" selected>Cutter detection</option>
+                        <option value="blade_crop">Blade crop</option>
+                    </select>
+                </label>
+                <button id="auto-annotate-btn" title="Ask the orchestrator for boxes">
                     ✨ Auto-annotate
                 </button>
-                <label title="Score cutoff for auto-annotation">
+                <label title="Detections at or above this score become boxes">
                     Threshold
                     <input type="number" id="auto-threshold" min="0" max="1" step="0.05" value="0.5">
+                </label>
+                <label title="Detections between this score and the threshold become candidates you can accept by clicking">
+                    Cand. ≥
+                    <input type="number" id="candidate-threshold" min="0" max="1" step="0.05" value="0.2">
                 </label>
 
                 <span class="divider"></span>
@@ -66,7 +78,9 @@
                 <img id="source-image" alt="">
                 <canvas id="draw-canvas"></canvas>
                 <div class="hint" id="canvas-hint">
-                    Click-and-drag to draw a box. Click an existing box to select
+                    Click-and-drag to draw a box. Click a model detection to
+                    reject it (click again to restore); click a dashed
+                    candidate to accept it. Click a hand-drawn box to select
                     it; press <kbd>Delete</kbd> to remove, double-click to rename.
                 </div>
             </div>
@@ -74,17 +88,24 @@
             <div class="boxes-panel">
                 <h4>Boxes <span id="box-count">(0)</span></h4>
                 <ul id="box-list"></ul>
+                <h4>Candidates <span id="candidate-count">(0)</span>
+                    <span class="hint-text" style="font-weight:normal;">— click to accept; unaccepted candidates are ignored</span>
+                </h4>
+                <ul id="candidate-list"></ul>
             </div>
         </section>
 
         <aside class="rightbar">
             <section>
                 <h3>Auto-annotate source</h3>
-                <label>Model endpoint (optional)</label>
-                <input type="text" id="endpoint" placeholder="https://…/predict">
                 <p class="hint-text">
-                    Leave blank to use a locally installed torchvision Faster R-CNN
-                    (falls back only if torchvision is available).
+                    Detections come from the dg-models-orchestrator
+                    (<code>ORCHESTRATOR_URL</code> / <code>ORCHESTRATOR_API_KEY</code>,
+                    or <code>orchestrator_url</code> / <code>orchestrator_api_key</code>
+                    in <code>detect_config.json</code>). Pick the model in the
+                    toolbar: <strong>Cutter detection</strong> labels cutter /
+                    lost / nozzle / ring_out from both detection models,
+                    <strong>Blade crop</strong> returns blade boxes.
                 </p>
             </section>
 

--- a/templates/detect.html
+++ b/templates/detect.html
@@ -70,6 +70,14 @@
 
                 <span class="divider"></span>
 
+                <button id="rotate-ccw-btn" title="Rotate image 90° counter-clockwise (saves an edited copy)">⟲ 90°</button>
+                <button id="rotate-cw-btn" title="Rotate image 90° clockwise (saves an edited copy)">⟳ 90°</button>
+                <button id="crop-btn" title="Drag a region on the image, then apply (saves an edited copy)">✂ Crop</button>
+                <button id="crop-apply-btn" class="primary" hidden>Apply crop</button>
+                <button id="crop-cancel-btn" hidden>Cancel</button>
+
+                <span class="divider"></span>
+
                 <button id="save-btn" class="primary">💾 Save</button>
                 <button id="clear-btn" class="danger">Clear all</button>
             </div>
@@ -82,6 +90,8 @@
                     reject it (click again to restore); click a dashed
                     candidate to accept it. Click a hand-drawn box to select
                     it; press <kbd>Delete</kbd> to remove, double-click to rename.
+                    Changes are auto-saved when you switch images. ✂ Crop /
+                    ⟲⟳ Rotate save an edited copy alongside the original.
                 </div>
             </div>
 

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -8,6 +8,9 @@
 
 <body>
     <div style="position: fixed; top: 8px; right: 12px; z-index: 10;">
+        <a href="/classify" style="background:#0d9488;color:#fff;padding:6px 12px;border-radius:4px;text-decoration:none;font-family:Arial;font-size:13px;margin-right:6px;">
+            Model Classify →
+        </a>
         <a href="/detect" style="background:#4f46e5;color:#fff;padding:6px 12px;border-radius:4px;text-decoration:none;font-family:Arial;font-size:13px;">
             Switch to Object Detection →
         </a>


### PR DESCRIPTION
## Summary

This PR refactors model inference to go through the dg-models-orchestrator service instead of direct TFServing calls or local models. It adds a new model-assisted classification UI and enhances object detection with candidate boxes (low-confidence detections) and image editing capabilities (rotate/crop).

## Key Changes

**Model Orchestration**
- New `orchestrator_client.py` module handles all communication with dg-models-orchestrator
- Replaces direct TFServing calls, local torchvision inference, and remote endpoint logic
- Supports detection modules: `cutter_detect` (dual-model), `blade_crop`
- Supports classification modules: `cutter_wear`, `wear_type`
- Configurable via `ORCHESTRATOR_URL` and `ORCHESTRATOR_API_KEY` environment variables or `detect_config.json`
- Handles EXIF orientation normalization before sending images to models

**Object Detection Enhancements**
- Detections now split into `boxes` (high-confidence, ≥threshold) and `candidates` (low-confidence, threshold band)
- Candidates shown as dashed boxes; clicking accepts them into the annotation set
- Model detections can be rejected by clicking (toggled state, not saved if rejected)
- Annotations now track rejected state and candidate detections separately
- Auto-annotation UI lets users select between detection models

**New Model-Assisted Classification UI**
- New `/classify` page at `templates/classify.html`
- Displays per-class confidence scores as clickable buttons
- Auto-predict on image load (configurable)
- Moves images to `sorted_files/<module>/<label>/` on label click
- Supports custom labels via text input

**Image Editing**
- New image rotation and cropping endpoints (`/api/detect/edit`)
- Edited copies saved as `<base>_edited.<ext>` (or `_edited_1`, `_edited_2` if taken)
- Crop mode with visual overlay; boxes and annotations transformed through edits
- Keyboard shortcuts: Escape to exit crop mode, Delete/Backspace to remove boxes

**Image List Filtering**
- New `_list_active_images()` hides original images that have edited copies (unless original has saved boxes)
- Reduces clutter when working with edited versions

**EXIF Orientation Handling**
- `_image_dimensions()` now returns browser-displayed (EXIF-oriented) dimensions
- Matches what users see on screen; critical for box coordinate accuracy

**UI/UX Improvements**
- Candidates shown with "?" prefix and amber styling
- Rejected boxes shown with "✕" prefix, grayed out, and diagonal lines
- Box count excludes rejected boxes
- Auto-save on image navigation (replaces discard confirmation)
- Toast notifications for user feedback
- Navigation links added to all pages

## Implementation Details

- Removed `base64` import (moved to orchestrator_client), added `re` for edited filename patterns
- Removed `CONFIG_PATH` constant from main.py (moved to orchestrator_client)
- `AutoAnnotateRequest` now uses `module` string instead of optional `endpoint`; added `candidate_threshold`
- `AnnotationPayload` now includes `candidates` list
- Detection parsing logic extracted to `orchestrator_client._parse_detection_prediction()` for reuse across modules
- Deduplication of overlapping detections (IOU > 0.5) in orchestrator_client
- Image editing creates new files; original annotations preserved unless explicitly edited

https://claude.ai/code/session_0141Ynpnf8mSFhkNg3748sF9