### PR TITLE
Improve annotation filtering and add keyboard shortcuts

### DIFF
--- a/static/detect.css
+++ b/static/detect.css
@@ -55,12 +55,17 @@ html, body {
     color: #374151;
 }
 
-#image-filter {
+#image-filter, #annotated-filter {
     width: 100%;
     padding: 6px 8px;
     margin-bottom: 8px;
     border: 1px solid #d1d5db;
     border-radius: 4px;
+    background: #fff;
+}
+
+#annotated-counter {
+    margin: 0 0 8px;
 }
 
 #image-list {

--- a/static/detect.js
+++ b/static/detect.js
@@ -81,8 +81,8 @@ function renderImageList() {
     state.images
         .filter((img) => !filter || img.name.toLowerCase().includes(filter))
         .filter((img) => {
-            if (annotatedFilter === "labelled") return img.annotated;
-            if (annotatedFilter === "unlabelled") return !img.annotated;
+            if (annotatedFilter === "annotated") return img.annotated;
+            if (annotatedFilter === "not-annotated") return !img.annotated;
             return true;
         })
         .forEach((img) => {
@@ -108,7 +108,26 @@ function renderImageList() {
 
 function updateProgress() {
     const annotated = state.images.filter((i) => i.annotated).length;
-    el("progress").textContent = `${annotated} / ${state.images.length} annotated`;
+    const total = state.images.length;
+    el("progress").textContent = `${annotated} / ${total} annotated`;
+    const counter = el("annotated-counter");
+    if (counter) {
+        counter.textContent = `${annotated} annotated · ${total - annotated} remaining`;
+    }
+    // Keep live counts on the filter options.
+    const sel = el("annotated-filter");
+    if (sel) {
+        const counts = {
+            "all": total,
+            "annotated": annotated,
+            "not-annotated": total - annotated,
+        };
+        Array.from(sel.options).forEach((opt) => {
+            if (opt.value in counts) {
+                opt.textContent = `${opt.dataset.label} (${counts[opt.value]})`;
+            }
+        });
+    }
 }
 
 async function selectImage(img) {
@@ -426,9 +445,32 @@ canvas().addEventListener("dblclick", (e) => {
 });
 
 window.addEventListener("keydown", (e) => {
-    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
+    const tag = e.target.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
     if (e.key === "Escape" && cropMode) {
         setCropMode(false);
+        return;
+    }
+    if (e.key === "c" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        // c toggles crop mode.
+        setCropMode(!cropMode);
+        e.preventDefault();
+        return;
+    }
+    if (e.key === "Enter" && cropMode) {
+        // Enter finishes cropping: applies the selected region.
+        if (state.cropRect) {
+            applyEdit({ crop: state.cropRect });
+        } else {
+            toast("Drag a region to crop first", true);
+        }
+        e.preventDefault();
+        return;
+    }
+    if (e.key === "a" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        // a triggers auto-annotation.
+        el("auto-annotate-btn").click();
+        e.preventDefault();
         return;
     }
     if ((e.key === "Delete" || e.key === "Backspace") && state.selected !== -1) {

--- a/templates/detect.html
+++ b/templates/detect.html
@@ -25,11 +25,12 @@
         <aside class="sidebar">
             <h3>Images</h3>
             <input type="text" id="image-filter" placeholder="Filter by name…">
-            <select id="annotated-filter">
-                <option value="all">All</option>
-                <option value="labelled">Labelled</option>
-                <option value="unlabelled">Unlabelled</option>
+            <select id="annotated-filter" title="Filter images by annotation status">
+                <option value="all" data-label="All">All</option>
+                <option value="annotated" data-label="Annotated">Annotated</option>
+                <option value="not-annotated" data-label="Not annotated">Not annotated</option>
             </select>
+            <p id="annotated-counter" class="hint-text"></p>
             <ul id="image-list"></ul>
         </aside>
 
@@ -56,7 +57,7 @@
                         <option value="blade_crop">Blade crop</option>
                     </select>
                 </label>
-                <button id="auto-annotate-btn" title="Ask the orchestrator for boxes">
+                <button id="auto-annotate-btn" title="Ask the orchestrator for boxes (A)">
                     ✨ Auto-annotate
                 </button>
                 <label title="Detections at or above this score become boxes">
@@ -72,8 +73,8 @@
 
                 <button id="rotate-ccw-btn" title="Rotate image 90° counter-clockwise (saves an edited copy)">⟲ 90°</button>
                 <button id="rotate-cw-btn" title="Rotate image 90° clockwise (saves an edited copy)">⟳ 90°</button>
-                <button id="crop-btn" title="Drag a region on the image, then apply (saves an edited copy)">✂ Crop</button>
-                <button id="crop-apply-btn" class="primary" hidden>Apply crop</button>
+                <button id="crop-btn" title="Drag a region on the image, then apply (saves an edited copy) (C)">✂ Crop</button>
+                <button id="crop-apply-btn" class="primary" title="Apply the selected crop (Enter)" hidden>Apply crop</button>
                 <button id="crop-cancel-btn" hidden>Cancel</button>
 
                 <span class="divider"></span>
@@ -92,6 +93,9 @@
                     it; press <kbd>Delete</kbd> to remove, double-click to rename.
                     Changes are auto-saved when you switch images. ✂ Crop /
                     ⟲⟳ Rotate save an edited copy alongside the original.
+                    Shortcuts: <kbd>C</kbd> crop mode, <kbd>Enter</kbd> apply
+                    crop, <kbd>Esc</kbd> cancel crop, <kbd>A</kbd>
+                    auto-annotate, <kbd>←</kbd>/<kbd>→</kbd> prev/next image.
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
Enhanced the image annotation interface with improved terminology, live filter counts, and keyboard shortcuts for common operations.

## Key Changes

- **Updated filter terminology**: Changed "labelled/unlabelled" to "annotated/not-annotated" for clarity and consistency
- **Live filter counts**: Filter dropdown options now display real-time counts of images in each category (e.g., "Annotated (42)")
- **Added annotation counter**: New progress indicator showing "X annotated · Y remaining" below the filter dropdown
- **Keyboard shortcuts**: 
  - `C` - Toggle crop mode
  - `Enter` - Apply crop (when in crop mode)
  - `A` - Trigger auto-annotation
  - `Esc` - Cancel crop mode (already existed)
- **Improved accessibility**: 
  - Added `title` attributes to filter dropdown and crop buttons documenting shortcuts
  - Updated help text to document all available keyboard shortcuts
  - Prevented keyboard shortcuts from triggering when focus is on SELECT elements
- **UI refinements**: 
  - Added `data-label` attributes to filter options for dynamic text updates
  - Improved button titles with shortcut hints
  - Better styling consistency for filter controls

## Implementation Details

The `updateProgress()` function now maintains live counts across the filter dropdown by storing counts in a map and updating each option's text content. The keyboard event handler was refactored to check for SELECT elements and now includes handlers for crop mode toggle, crop application, and auto-annotation triggers with proper modifier key checks to avoid conflicts.

https://claude.ai/code/session_01GwoWN3Q7W6BNdc5tjfX299